### PR TITLE
Port to Qt6

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 120
+---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 4.0)
 
-project(v4l2ucp)
-set(V4L2UCP_VERSION 2.0.2)
+project(v4l2ucp LANGUAGES C CXX)
+set(CXX_STANDARD 20)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(V4L2UCP_VERSION 2.1.0)
 
 add_definitions(-Wall -DV4L2UCP_VERSION="${V4L2UCP_VERSION}")
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets REQUIRED)
 
 MESSAGE(STATUS "Looking for libv4l")
 find_library(V4L2_LIBRARY v4l2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_AUTOUIC ON)
 include_directories(${CMAKE_BINARY_DIR}/src)
 
 add_executable(v4l2ucp ${SOURCES} ${MOC_SOURCES} ${UI_HEADERS} ${RC_SOURCES})
-target_link_libraries(v4l2ucp Qt5::Widgets ${V4L2_LIBRARY})
+target_link_libraries(v4l2ucp Qt6::Core Qt6::Widgets ${V4L2_LIBRARY})
 
 add_executable(v4l2ctrl v4l2ctrl.c)
 target_link_libraries(v4l2ctrl ${V4L2_LIBRARY})

--- a/src/mainWindow.cpp
+++ b/src/mainWindow.cpp
@@ -45,7 +45,7 @@ MainWindow::MainWindow(QWidget *parent, const char *name) : QMainWindow(parent),
     setWindowTitle(name);
     setWindowIcon(QIcon(":/v4l2ucp.png"));
     QMenu *menu = new QMenu(this);
-    menu->addAction("&Open", Qt::CTRL | Qt::Key_O, [this] { this->fileOpen(); });
+    menu->addAction("&Open", Qt::CTRL | Qt::Key_O, &MainWindow::fileOpen);
     menu->addAction("&Close", Qt::CTRL | Qt::Key_W, [this] { this->close(); });
     menu->addSeparator();
     menu->addAction("E&xit", Qt::CTRL | Qt::Key_Q, [] { qApp->exit(); });
@@ -91,7 +91,7 @@ MainWindow::MainWindow(QWidget *parent, const char *name) : QMainWindow(parent),
 }
 
 void MainWindow::fileOpen() {
-    QFileDialog *diag = new QFileDialog(this, "Select V4L2 device", "/dev",
+    QFileDialog *diag = new QFileDialog(nullptr, "Select V4L2 device", "/dev",
                                         "V4L2 Devices (video* vout* vbi* radio*);;"
                                         "Video Capture (video*);;"
                                         "Video Output (vout*);;"
@@ -102,12 +102,12 @@ void MainWindow::fileOpen() {
     diag->setFilter(QDir::AllEntries | QDir::System);
 
     connect(diag, &QFileDialog::fileSelected, [diag](const QString &newfilename) {
-        diag->close();
         if (!newfilename.isEmpty()) {
             MainWindow *w = openFile(newfilename.toUtf8());
             if (w)
                 w->show();
         }
+        diag->close();
     });
 
     diag->show();

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -27,7 +27,7 @@ class MainWindow : public QMainWindow {
     Q_OBJECT
 
   public slots:
-    void fileOpen();
+    static void fileOpen();
     void updateDisabled();
     void update1Sec();
     void update5Sec();

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -17,17 +17,16 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
  */
-#include <QMainWindow>
-#include <QTimer>
-#include <QMenu>
 #include <QGridLayout>
+#include <QMainWindow>
+#include <QMenu>
 #include <QProcess>
+#include <QTimer>
 
-class MainWindow : public QMainWindow
-{
+class MainWindow : public QMainWindow {
     Q_OBJECT
-    
-public slots:
+
+  public slots:
     void fileOpen();
     void updateDisabled();
     void update1Sec();
@@ -42,15 +41,15 @@ public slots:
     void configurePreview();
     void previewProcError(QProcess::ProcessError er);
     void previewFinished(int exitCode, QProcess::ExitStatus status);
-   
-signals:
+
+  signals:
     void updateNow();
 
-public:
+  public:
     static MainWindow *openFile(const char *fileName);
     ~MainWindow();
 
-private:
+  private:
     QMenu *updateMenu, *resetMenu;
     int fd;
     QAction *resetAllId;
@@ -58,7 +57,7 @@ private:
     QTimer timer;
     QProcess *previewProcess;
     QString filename;
-    
-    MainWindow(QWidget *parent=0, const char *name=0);
+
+    MainWindow(QWidget *parent = 0, const char *name = 0);
     void add_control(struct v4l2_queryctrl &ctrl, int fd, QWidget *parent, QGridLayout *);
 };

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -57,6 +57,7 @@ private:
     QAction *updateActions[6];
     QTimer timer;
     QProcess *previewProcess;
+    QString filename;
     
     MainWindow(QWidget *parent=0, const char *name=0);
     void add_control(struct v4l2_queryctrl &ctrl, int fd, QWidget *parent, QGridLayout *);

--- a/src/previewSettings.cpp
+++ b/src/previewSettings.cpp
@@ -73,14 +73,12 @@ void PreviewSettingsDialog::loadSettings()
         for (begin = envList.begin(),
             end = envList.end(); begin != end; begin++)
         {
-            QListWidgetItem *item;
-            item = new QListWidgetItem((*begin).toString(), ui.envList);
+            new QListWidgetItem((*begin).toString(), ui.envList);
         }
     }
     else
     {
-        QListWidgetItem *item;
-        item = new QListWidgetItem("LD_PRELOAD=/usr/lib/libv4l/v4l2convert.so", ui.envList);
+        new QListWidgetItem("LD_PRELOAD=/usr/lib/libv4l/v4l2convert.so", ui.envList);
     }
 
     if (settings.contains(SETTINGS_ARG_LIST))
@@ -90,14 +88,12 @@ void PreviewSettingsDialog::loadSettings()
         for (begin = argList.begin(),
             end = argList.end(); begin != end; begin++)
         {
-            QListWidgetItem *item;
-            item = new QListWidgetItem((*begin).toString(), ui.argList);
+            new QListWidgetItem((*begin).toString(), ui.argList);
         }
     }
     else
     {
-        QListWidgetItem *item;
-        item = new QListWidgetItem("tv://", ui.argList);
+        new QListWidgetItem("tv://", ui.argList);
     }
 }
 
@@ -150,13 +146,12 @@ void PreviewSettingsDialog::addEnvItemClicked()
 {
     if (!ui.envEdit->text().isEmpty())
     {
-        QListWidgetItem *item = NULL;
-        item = new QListWidgetItem(ui.envEdit->text(), ui.envList);
+        new QListWidgetItem(ui.envEdit->text(), ui.envList);
         ui.envEdit->clear();
     }
     else
     {
-        QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!", "OK");
+        QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!");
     }
 }
 
@@ -164,13 +159,12 @@ void PreviewSettingsDialog::addArgItemClicked()
 {
     if (!ui.argEdit->text().isEmpty())
     {
-        QListWidgetItem *item = NULL;
-        item = new QListWidgetItem(ui.argEdit->text(), ui.argList);
+        QListWidgetItem *item = new QListWidgetItem(ui.argEdit->text(), ui.argList);
         ui.argEdit->clear();
     }
     else
     {
-        QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!", "OK");
+        QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!");
     }
 }
 void PreviewSettingsDialog::listCurItemChanged(QListWidgetItem *newItem, QListWidgetItem *oldItem)
@@ -189,7 +183,7 @@ void PreviewSettingsDialog::delEnvItemClicked()
     }
     else
     {
-        QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.", "OK");
+        QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.");
     }
 }
 
@@ -201,20 +195,18 @@ void PreviewSettingsDialog::delArgItemClicked()
     }
     else
     {
-        QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.", "OK");
+        QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.");
     }
 }
 
 void PreviewSettingsDialog::defaultsClicked()
 {
-    QListWidgetItem *item;
-
     ui.argList->clear();
     ui.envList->clear();
     ui.argEdit->clear();
     ui.envEdit->clear();
     ui.appNameEdit->setText("mplayer");
 
-    item = new QListWidgetItem("LD_PRELOAD=/usr/lib/libv4l/v4l2convert.so", ui.envList);
-    item = new QListWidgetItem("tv://", ui.argList);
+    new QListWidgetItem("LD_PRELOAD=/usr/lib/libv4l/v4l2convert.so", ui.envList);
+    new QListWidgetItem("tv://", ui.argList);
 }

--- a/src/previewSettings.cpp
+++ b/src/previewSettings.cpp
@@ -21,109 +21,79 @@
 #include <QMessageBox>
 #include <QSettings>
 
-
-PreviewSettingsDialog::PreviewSettingsDialog(QWidget *parent)
-    : QDialog(parent)
-{
+PreviewSettingsDialog::PreviewSettingsDialog(QWidget *parent) : QDialog(parent) {
     ui.setupUi(this);
 
     connectSignals();
     loadSettings();
 }
 
-void PreviewSettingsDialog::connectSignals()
-{
-    QObject::connect(ui.envList, SIGNAL(itemDoubleClicked(QListWidgetItem *)),
-        this, SLOT(envItemDoubleClicked(QListWidgetItem *)));
-    QObject::connect(ui.envList, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)),
-        this, SLOT(listCurItemChanged(QListWidgetItem *, QListWidgetItem *)));
-    QObject::connect(ui.argList, SIGNAL(itemDoubleClicked(QListWidgetItem *)),
-        this, SLOT(argItemDoubleClicked(QListWidgetItem *)));
-    QObject::connect(ui.argList, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)),
-        this, SLOT(listCurItemChanged(QListWidgetItem *, QListWidgetItem *)));
-    QObject::connect(ui.addEnvBut, SIGNAL(clicked()),
-        this, SLOT(addEnvItemClicked()));
-    QObject::connect(ui.addArgBut, SIGNAL(clicked()),
-        this, SLOT(addArgItemClicked()));
-    QObject::connect(ui.removeEnvBut, SIGNAL(clicked()),
-        this, SLOT(delEnvItemClicked()));
-    QObject::connect(ui.removeArgBut, SIGNAL(clicked()),
-        this, SLOT(delArgItemClicked()));
-    QObject::connect(ui.defaultsBut, SIGNAL(clicked()),
-        this, SLOT(defaultsClicked()));
+void PreviewSettingsDialog::connectSignals() {
+    QObject::connect(ui.envList, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this,
+                     SLOT(envItemDoubleClicked(QListWidgetItem *)));
+    QObject::connect(ui.envList, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this,
+                     SLOT(listCurItemChanged(QListWidgetItem *, QListWidgetItem *)));
+    QObject::connect(ui.argList, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this,
+                     SLOT(argItemDoubleClicked(QListWidgetItem *)));
+    QObject::connect(ui.argList, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this,
+                     SLOT(listCurItemChanged(QListWidgetItem *, QListWidgetItem *)));
+    QObject::connect(ui.addEnvBut, SIGNAL(clicked()), this, SLOT(addEnvItemClicked()));
+    QObject::connect(ui.addArgBut, SIGNAL(clicked()), this, SLOT(addArgItemClicked()));
+    QObject::connect(ui.removeEnvBut, SIGNAL(clicked()), this, SLOT(delEnvItemClicked()));
+    QObject::connect(ui.removeArgBut, SIGNAL(clicked()), this, SLOT(delArgItemClicked()));
+    QObject::connect(ui.defaultsBut, SIGNAL(clicked()), this, SLOT(defaultsClicked()));
 }
 
-void PreviewSettingsDialog::loadSettings()
-{
+void PreviewSettingsDialog::loadSettings() {
     QSettings settings(APP_ORG, APP_NAME);
 
-    if (settings.contains(SETTINGS_APP_BINARY_NAME))
-    {
+    if (settings.contains(SETTINGS_APP_BINARY_NAME)) {
         ui.appNameEdit->setText(settings.value(SETTINGS_APP_BINARY_NAME).toString());
-    }
-    else
-    {
+    } else {
         ui.appNameEdit->setText("mplayer");
     }
 
-    if (settings.contains(SETTINGS_ENV_LIST))
-    {
+    if (settings.contains(SETTINGS_ENV_LIST)) {
         QList<QVariant> envList = settings.value(SETTINGS_ENV_LIST).toList();
         QList<QVariant>::iterator begin, end;
-        for (begin = envList.begin(),
-            end = envList.end(); begin != end; begin++)
-        {
+        for (begin = envList.begin(), end = envList.end(); begin != end; begin++) {
             new QListWidgetItem((*begin).toString(), ui.envList);
         }
-    }
-    else
-    {
+    } else {
         new QListWidgetItem("LD_PRELOAD=/usr/lib/libv4l/v4l2convert.so", ui.envList);
     }
 
-    if (settings.contains(SETTINGS_ARG_LIST))
-    {
+    if (settings.contains(SETTINGS_ARG_LIST)) {
         QList<QVariant> argList = settings.value(SETTINGS_ARG_LIST).toList();
         QList<QVariant>::iterator begin, end;
-        for (begin = argList.begin(),
-            end = argList.end(); begin != end; begin++)
-        {
+        for (begin = argList.begin(), end = argList.end(); begin != end; begin++) {
             new QListWidgetItem((*begin).toString(), ui.argList);
         }
-    }
-    else
-    {
+    } else {
         new QListWidgetItem("tv://", ui.argList);
     }
 }
 
-PreviewSettingsDialog::~PreviewSettingsDialog()
-{
-}
+PreviewSettingsDialog::~PreviewSettingsDialog() {}
 
-void PreviewSettingsDialog::saveSettings()
-{
+void PreviewSettingsDialog::saveSettings() {
     QSettings settings(APP_ORG, APP_NAME);
 
     settings.setValue(SETTINGS_APP_BINARY_NAME, ui.appNameEdit->text());
     QList<QVariant> varList;
     QList<QVariant>::iterator begin, end;
     QListWidgetItem *item;
-    for (int i = 0; i < ui.envList->count(); i++)
-    {
+    for (int i = 0; i < ui.envList->count(); i++) {
         item = ui.envList->item(i);
-        if (item)
-        {
+        if (item) {
             varList << QVariant(item->text());
         }
     }
     settings.setValue(SETTINGS_ENV_LIST, varList);
     varList.clear();
-    for (int i = 0; i < ui.argList->count(); i++)
-    {
+    for (int i = 0; i < ui.argList->count(); i++) {
         item = ui.argList->item(i);
-        if (item)
-        {
+        if (item) {
             varList << QVariant(item->text());
         }
     }
@@ -132,75 +102,50 @@ void PreviewSettingsDialog::saveSettings()
     settings.sync();
 }
 
-void PreviewSettingsDialog::envItemDoubleClicked(QListWidgetItem *item)
-{
-    ui.envList->openPersistentEditor(item);
-}
+void PreviewSettingsDialog::envItemDoubleClicked(QListWidgetItem *item) { ui.envList->openPersistentEditor(item); }
 
-void PreviewSettingsDialog::argItemDoubleClicked(QListWidgetItem *item)
-{
-    ui.argList->openPersistentEditor(item);
-}
+void PreviewSettingsDialog::argItemDoubleClicked(QListWidgetItem *item) { ui.argList->openPersistentEditor(item); }
 
-void PreviewSettingsDialog::addEnvItemClicked()
-{
-    if (!ui.envEdit->text().isEmpty())
-    {
+void PreviewSettingsDialog::addEnvItemClicked() {
+    if (!ui.envEdit->text().isEmpty()) {
         new QListWidgetItem(ui.envEdit->text(), ui.envList);
         ui.envEdit->clear();
-    }
-    else
-    {
+    } else {
         QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!");
     }
 }
 
-void PreviewSettingsDialog::addArgItemClicked()
-{
-    if (!ui.argEdit->text().isEmpty())
-    {
+void PreviewSettingsDialog::addArgItemClicked() {
+    if (!ui.argEdit->text().isEmpty()) {
         QListWidgetItem *item = new QListWidgetItem(ui.argEdit->text(), ui.argList);
         ui.argEdit->clear();
-    }
-    else
-    {
+    } else {
         QMessageBox::warning(NULL, "v4l2ucp", "Empty values seems to be meaningless!");
     }
 }
-void PreviewSettingsDialog::listCurItemChanged(QListWidgetItem *newItem, QListWidgetItem *oldItem)
-{
-    if (oldItem)
-    {
+void PreviewSettingsDialog::listCurItemChanged(QListWidgetItem *newItem, QListWidgetItem *oldItem) {
+    if (oldItem) {
         oldItem->listWidget()->closePersistentEditor(oldItem);
     }
 }
 
-void PreviewSettingsDialog::delEnvItemClicked()
-{
-    if (ui.envList->currentItem())
-    {
+void PreviewSettingsDialog::delEnvItemClicked() {
+    if (ui.envList->currentItem()) {
         delete ui.envList->currentItem();
-    }
-    else
-    {
+    } else {
         QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.");
     }
 }
 
-void PreviewSettingsDialog::delArgItemClicked()
-{
-    if (ui.argList->currentItem())
-    {
+void PreviewSettingsDialog::delArgItemClicked() {
+    if (ui.argList->currentItem()) {
         delete ui.argList->currentItem();
-    }
-    else
-    {
+    } else {
         QMessageBox::warning(NULL, "v4l2ucp", "Select entry to delete.");
     }
 }
 
-void PreviewSettingsDialog::defaultsClicked()
-{
+void PreviewSettingsDialog::defaultsClicked() {
     ui.argList->clear();
     ui.envList->clear();
     ui.argEdit->clear();

--- a/src/previewSettings.h
+++ b/src/previewSettings.h
@@ -17,8 +17,8 @@
 
  */
 
-#include <QDialog>
 #include "ui_previewSettings.h"
+#include <QDialog>
 
 #define APP_ORG "v4l2ucp"
 #define APP_NAME "v4l2ucp"
@@ -28,31 +28,29 @@
 
 class QListWidgetItem;
 
-class PreviewSettingsDialog : public QDialog
-{
+class PreviewSettingsDialog : public QDialog {
     Q_OBJECT
 
-    public slots:
-        void envItemDoubleClicked(QListWidgetItem *item);
-        void argItemDoubleClicked(QListWidgetItem *item);
-        void listCurItemChanged(QListWidgetItem *newItem, QListWidgetItem *oldItem);
+  public slots:
+    void envItemDoubleClicked(QListWidgetItem *item);
+    void argItemDoubleClicked(QListWidgetItem *item);
+    void listCurItemChanged(QListWidgetItem *newItem, QListWidgetItem *oldItem);
 
-        void addEnvItemClicked();
-        void addArgItemClicked();
-        void delEnvItemClicked();
-        void delArgItemClicked();
-        void defaultsClicked();
+    void addEnvItemClicked();
+    void addArgItemClicked();
+    void delEnvItemClicked();
+    void delArgItemClicked();
+    void defaultsClicked();
 
-    public:
+  public:
+    PreviewSettingsDialog(QWidget *parent = NULL);
+    ~PreviewSettingsDialog();
+    void saveSettings();
 
-        PreviewSettingsDialog(QWidget *parent = NULL);
-        ~PreviewSettingsDialog();
-        void saveSettings();
+  protected:
+    Ui::previewSettingsDialog ui;
 
-    protected:
-        Ui::previewSettingsDialog ui;
-
-    private:
-        void loadSettings();
-        void connectSignals();
+  private:
+    void loadSettings();
+    void connectSignals();
 };

--- a/src/v4l2controls.cpp
+++ b/src/v4l2controls.cpp
@@ -128,9 +128,8 @@ void V4L2Control::updateHardware()
     c.id = cid;
     c.value = getValue();
     if(v4l2_ioctl(fd, VIDIOC_S_CTRL, &c) == -1) {
-        QString msg;
-	msg.sprintf("Unable to set %s\n%s", name, strerror(errno));
-	QMessageBox::warning(this, "Unable to set control", msg, "OK");
+        QString msg = QString("Unable to set %1\n%2").arg(name, strerror(errno));
+	QMessageBox::warning(this, "Unable to set control", msg);
 	updateStatus(false);
     } else
         updateStatus(true);
@@ -141,10 +140,8 @@ void V4L2Control::updateStatus(bool hwChanged)
     struct v4l2_queryctrl ctrl = { 0 };
     ctrl.id = cid;
     if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == -1) {
-        QString msg;
-	msg.sprintf("Unable to get the status of %s\n%s", name,
-	            strerror(errno));
-	QMessageBox::warning(this, "Unable to get control status", msg, "OK");
+        QString msg = QString("Unable to get status of %1\n%2").arg(name, strerror(errno));
+        QMessageBox::warning(this, "Unable to get control status", msg);
     } else {
         queryCleanup(&ctrl);
         setEnabled(!(ctrl.flags & (V4L2_CTRL_FLAG_GRABBED|V4L2_CTRL_FLAG_READ_ONLY|V4L2_CTRL_FLAG_INACTIVE)));
@@ -164,10 +161,8 @@ void V4L2Control::updateStatus(bool hwChanged)
     struct v4l2_control c;
     c.id = cid;
     if(v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == -1) {
-        QString msg;
-	msg.sprintf("Unable to get %s\n%s", name,
-	            strerror(errno));
-	QMessageBox::warning(this, "Unable to get control", msg, "OK");
+        QString msg = QString("Unable to get %1\n%2").arg(name, strerror(errno));
+        QMessageBox::warning(this, "Unable to get control", msg);
     } else {
         cacheValue(c);
         if(c.value != getValue())
@@ -304,10 +299,9 @@ V4L2MenuControl::V4L2MenuControl
         if(v4l2_ioctl(fd, VIDIOC_QUERYMENU, &qm) == 0) {
             cb->insertItem(i, (const char *)qm.name);
         } else {
-            QString msg;
-            msg.sprintf("Unable to get menu item for %s, index=%d\n"
-	                "Will use Unknown", name, qm.index);
-            QMessageBox::warning(this, "Unable to get menu item", msg, "OK");
+            QString msg = QString("Unable to get menu item for %1, index=%2\n"
+	                "Will use Unknown").arg(name).arg(qm.index);
+            QMessageBox::warning(this, "Unable to get menu item", msg);
             cb->insertItem(i, "Unknown");
         }
     }

--- a/src/v4l2controls.cpp
+++ b/src/v4l2controls.cpp
@@ -17,15 +17,15 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
  */
-#include <sys/ioctl.h>
 #include <cerrno>
 #include <cstring>
 #include <libv4l2.h>
+#include <sys/ioctl.h>
 
-#include <QPushButton>
 #include <QLabel>
-#include <QValidator>
 #include <QMessageBox>
+#include <QPushButton>
+#include <QValidator>
 
 #include "mainWindow.h"
 #include "v4l2controls.h"
@@ -35,18 +35,15 @@ int V4L2Control::focus_auto = 0;
 int V4L2Control::hue_auto = 0;
 int V4L2Control::whitebalance_auto = 0;
 
-V4L2Control::V4L2Control(int fd, const struct v4l2_queryctrl &ctrl,
-                         QWidget *parent, MainWindow *mw) :
-    QWidget(parent), cid(ctrl.id), default_value(ctrl.default_value), mw(mw)
-{
+V4L2Control::V4L2Control(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw)
+    : QWidget(parent), cid(ctrl.id), default_value(ctrl.default_value), mw(mw) {
     this->fd = fd;
     strncpy(name, (const char *)ctrl.name, sizeof(name));
-    name[sizeof(name)-1] = '\0';
+    name[sizeof(name) - 1] = '\0';
     this->setLayout(&layout);
 }
 
-void V4L2Control::cacheValue(const struct v4l2_control &c)
-{
+void V4L2Control::cacheValue(const struct v4l2_control &c) {
     switch (c.id) {
     case V4L2_CID_EXPOSURE_AUTO:
         exposure_auto = c.value;
@@ -63,15 +60,14 @@ void V4L2Control::cacheValue(const struct v4l2_control &c)
     }
 }
 
-void V4L2Control::queryCleanup(struct v4l2_queryctrl *ctrl)
-{
+void V4L2Control::queryCleanup(struct v4l2_queryctrl *ctrl) {
     switch (ctrl->id) {
     case V4L2_CID_EXPOSURE_ABSOLUTE:
         switch (exposure_auto) {
-            case V4L2_EXPOSURE_AUTO:
-            case V4L2_EXPOSURE_APERTURE_PRIORITY:
-                ctrl->flags |= V4L2_CTRL_FLAG_GRABBED;
-                break;
+        case V4L2_EXPOSURE_AUTO:
+        case V4L2_EXPOSURE_APERTURE_PRIORITY:
+            ctrl->flags |= V4L2_CTRL_FLAG_GRABBED;
+            break;
         }
         break;
 
@@ -80,10 +76,10 @@ void V4L2Control::queryCleanup(struct v4l2_queryctrl *ctrl)
         /* Fall through */
     case V4L2_CID_IRIS_ABSOLUTE:
         switch (exposure_auto) {
-            case V4L2_EXPOSURE_AUTO:
-            case V4L2_EXPOSURE_SHUTTER_PRIORITY:
-                ctrl->flags |= V4L2_CTRL_FLAG_GRABBED;
-                break;
+        case V4L2_EXPOSURE_AUTO:
+        case V4L2_EXPOSURE_SHUTTER_PRIORITY:
+            ctrl->flags |= V4L2_CTRL_FLAG_GRABBED;
+            break;
         }
         break;
 
@@ -122,57 +118,54 @@ void V4L2Control::queryCleanup(struct v4l2_queryctrl *ctrl)
     }
 }
 
-void V4L2Control::updateHardware()
-{
+void V4L2Control::updateHardware() {
     struct v4l2_control c;
     c.id = cid;
     c.value = getValue();
-    if(v4l2_ioctl(fd, VIDIOC_S_CTRL, &c) == -1) {
+    if (v4l2_ioctl(fd, VIDIOC_S_CTRL, &c) == -1) {
         QString msg = QString("Unable to set %1\n%2").arg(name, strerror(errno));
-	QMessageBox::warning(this, "Unable to set control", msg);
-	updateStatus(false);
+        QMessageBox::warning(this, "Unable to set control", msg);
+        updateStatus(false);
     } else
         updateStatus(true);
 }
 
-void V4L2Control::updateStatus(bool hwChanged)
-{
-    struct v4l2_queryctrl ctrl = { 0 };
+void V4L2Control::updateStatus(bool hwChanged) {
+    struct v4l2_queryctrl ctrl = {0};
     ctrl.id = cid;
-    if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == -1) {
+    if (v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == -1) {
         QString msg = QString("Unable to get status of %1\n%2").arg(name, strerror(errno));
         QMessageBox::warning(this, "Unable to get control status", msg);
     } else {
         queryCleanup(&ctrl);
-        setEnabled(!(ctrl.flags & (V4L2_CTRL_FLAG_GRABBED|V4L2_CTRL_FLAG_READ_ONLY|V4L2_CTRL_FLAG_INACTIVE)));
+        setEnabled(!(ctrl.flags & (V4L2_CTRL_FLAG_GRABBED | V4L2_CTRL_FLAG_READ_ONLY | V4L2_CTRL_FLAG_INACTIVE)));
     }
 
     if (hwChanged && (ctrl.flags & V4L2_CTRL_FLAG_UPDATE))
         mw->timerShot();
 
 #ifdef V4L2_CTRL_FLAG_WRITE_ONLY
-    if(ctrl.flags & V4L2_CTRL_FLAG_WRITE_ONLY)
+    if (ctrl.flags & V4L2_CTRL_FLAG_WRITE_ONLY)
         return;
 #endif
 
-    if(ctrl.type == V4L2_CTRL_TYPE_BUTTON)
+    if (ctrl.type == V4L2_CTRL_TYPE_BUTTON)
         return;
 
     struct v4l2_control c;
     c.id = cid;
-    if(v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == -1) {
+    if (v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == -1) {
         QString msg = QString("Unable to get %1\n%2").arg(name, strerror(errno));
         QMessageBox::warning(this, "Unable to get control", msg);
     } else {
         cacheValue(c);
-        if(c.value != getValue())
-	    setValue(c.value);
+        if (c.value != getValue())
+            setValue(c.value);
     }
 }
 
-void V4L2Control::resetToDefault()
-{
-    if(isEnabled()) {
+void V4L2Control::resetToDefault() {
+    if (isEnabled()) {
         setValue(default_value);
         updateHardware();
     }
@@ -181,20 +174,17 @@ void V4L2Control::resetToDefault()
 /*
  * V4L2IntegerControl
  */
-V4L2IntegerControl::V4L2IntegerControl
-    (int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw) :
-    V4L2Control(fd, ctrl, parent, mw),
-    minimum(ctrl.minimum), maximum(ctrl.maximum), step(ctrl.step)
-{
-    int pageStep = (maximum-minimum)/10;
-    if(step > pageStep)
+V4L2IntegerControl::V4L2IntegerControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw)
+    : V4L2Control(fd, ctrl, parent, mw), minimum(ctrl.minimum), maximum(ctrl.maximum), step(ctrl.step) {
+    int pageStep = (maximum - minimum) / 10;
+    if (step > pageStep)
         pageStep = step;
     sl = new QSlider(Qt::Horizontal, this);
     sl->setMinimum(minimum);
     sl->setMaximum(maximum);
     sl->setPageStep(pageStep);
     sl->setValue(default_value);
-    //sl->setLineStep(step);
+    // sl->setLineStep(step);
     sl->setVisible(true);
     this->layout.addWidget(sl);
 
@@ -204,26 +194,22 @@ V4L2IntegerControl::V4L2IntegerControl
     le->setText(defStr);
     le->setValidator(new QIntValidator(minimum, maximum, this));
     this->layout.addWidget(le);
-    
-    QObject::connect( sl, SIGNAL(valueChanged(int)),
-                      this, SLOT(SetValueFromSlider()) );
-    QObject::connect( sl, SIGNAL(sliderReleased()),
-                      this, SLOT(SetValueFromSlider()) );
-    QObject::connect( le, SIGNAL(returnPressed()),
-                      this, SLOT(SetValueFromText()) );
+
+    QObject::connect(sl, SIGNAL(valueChanged(int)), this, SLOT(SetValueFromSlider()));
+    QObject::connect(sl, SIGNAL(sliderReleased()), this, SLOT(SetValueFromSlider()));
+    QObject::connect(le, SIGNAL(returnPressed()), this, SLOT(SetValueFromText()));
     updateStatus();
 }
 
-void V4L2IntegerControl::setValue(int val)
-{
-    if(val < minimum)
+void V4L2IntegerControl::setValue(int val) {
+    if (val < minimum)
         val = minimum;
-    if(val > maximum)
+    if (val > maximum)
         val = maximum;
-    if(step > 1) {
-        int mod = (val-minimum)%step;
-        if(mod > step/2) {
-            val += step-mod;
+    if (step > 1) {
+        int mod = (val - minimum) % step;
+        if (mod > step / 2) {
+            val += step - mod;
         } else {
             val -= mod;
         }
@@ -232,26 +218,21 @@ void V4L2IntegerControl::setValue(int val)
     str.setNum(val);
     le->setText(str);
 
-	/* FIXME: find clean solution to prevent infinite loop */
-	sl->blockSignals(true);
+    /* FIXME: find clean solution to prevent infinite loop */
+    sl->blockSignals(true);
     sl->setValue(val);
-	sl->blockSignals(false);
+    sl->blockSignals(false);
 }
 
-int V4L2IntegerControl::getValue()
-{
-    return sl->value();
-}
+int V4L2IntegerControl::getValue() { return sl->value(); }
 
-void V4L2IntegerControl::SetValueFromSlider()
-{
+void V4L2IntegerControl::SetValueFromSlider() {
     setValue(sl->value());
     updateHardware();
 }
 
-void V4L2IntegerControl::SetValueFromText()
-{
-    if(le->hasAcceptableInput()) {
+void V4L2IntegerControl::SetValueFromText() {
+    if (le->hasAcceptableInput()) {
         setValue(le->text().toInt());
         updateHardware();
     } else {
@@ -262,67 +243,50 @@ void V4L2IntegerControl::SetValueFromText()
 /*
  * V4L2BooleanControl
  */
-V4L2BooleanControl::V4L2BooleanControl
-    (int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw) :
-    V4L2Control(fd, ctrl, parent, mw),
-    cb(new QCheckBox(this))
-{
+V4L2BooleanControl::V4L2BooleanControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw)
+    : V4L2Control(fd, ctrl, parent, mw), cb(new QCheckBox(this)) {
     this->layout.addWidget(cb);
-    QObject::connect( cb, SIGNAL(clicked()), this, SLOT(updateHardware()) );
+    QObject::connect(cb, SIGNAL(clicked()), this, SLOT(updateHardware()));
     updateStatus();
 }
 
-void V4L2BooleanControl::setValue(int val)
-{
-    cb->setChecked(val != 0);
-}
+void V4L2BooleanControl::setValue(int val) { cb->setChecked(val != 0); }
 
-int V4L2BooleanControl::getValue()
-{
-    return cb->isChecked();
-}
+int V4L2BooleanControl::getValue() { return cb->isChecked(); }
 
 /*
  * V4L2MenuControl
  */
-V4L2MenuControl::V4L2MenuControl
-    (int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw) :
-    V4L2Control(fd, ctrl, parent, mw)
-{
+V4L2MenuControl::V4L2MenuControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw)
+    : V4L2Control(fd, ctrl, parent, mw) {
     cb = new QComboBox(this);
     this->layout.addWidget(cb);
-    
-    for(int i=ctrl.minimum; i<=ctrl.maximum; i++) {
+
+    for (int i = ctrl.minimum; i <= ctrl.maximum; i++) {
         struct v4l2_querymenu qm;
         qm.id = ctrl.id;
         qm.index = i;
-        if(v4l2_ioctl(fd, VIDIOC_QUERYMENU, &qm) == 0) {
+        if (v4l2_ioctl(fd, VIDIOC_QUERYMENU, &qm) == 0) {
             cb->insertItem(i, (const char *)qm.name);
         } else {
             QString msg = QString("Unable to get menu item for %1, index=%2\n"
-	                "Will use Unknown").arg(name).arg(qm.index);
+                                  "Will use Unknown")
+                              .arg(name)
+                              .arg(qm.index);
             QMessageBox::warning(this, "Unable to get menu item", msg);
             cb->insertItem(i, "Unknown");
         }
     }
     cb->setCurrentIndex(default_value);
-    QObject::connect( cb, SIGNAL(activated(int)),
-                      this, SLOT(menuActivated(int)) );
+    QObject::connect(cb, SIGNAL(activated(int)), this, SLOT(menuActivated(int)));
     updateStatus();
 }
 
-void V4L2MenuControl::setValue(int val)
-{
-    cb->setCurrentIndex(val);
-}
+void V4L2MenuControl::setValue(int val) { cb->setCurrentIndex(val); }
 
-int V4L2MenuControl::getValue()
-{
-    return cb->currentIndex();
-}
+int V4L2MenuControl::getValue() { return cb->currentIndex(); }
 
-void V4L2MenuControl::menuActivated(int val)
-{
+void V4L2MenuControl::menuActivated(int val) {
     setValue(val);
     updateHardware();
 }
@@ -330,15 +294,11 @@ void V4L2MenuControl::menuActivated(int val)
 /*
  * V4L2ButtonControl
  */
-V4L2ButtonControl::V4L2ButtonControl
-    (int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw) :
-    V4L2Control(fd, ctrl, parent, mw)
-{
+V4L2ButtonControl::V4L2ButtonControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw)
+    : V4L2Control(fd, ctrl, parent, mw) {
     QPushButton *pb = new QPushButton((const char *)ctrl.name, this);
     this->layout.addWidget(pb);
-    QObject::connect( pb, SIGNAL(clicked()), this, SLOT(updateHardware()) );
+    QObject::connect(pb, SIGNAL(clicked()), this, SLOT(updateHardware()));
 }
 
-void V4L2ButtonControl::resetToDefault()
-{
-}
+void V4L2ButtonControl::resetToDefault() {}

--- a/src/v4l2controls.h
+++ b/src/v4l2controls.h
@@ -17,36 +17,35 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
  */
-#include <sys/time.h>
-#include <linux/types.h>          /* for videodev2.h */
+#include <linux/types.h> /* for videodev2.h */
 #include <linux/videodev2.h>
+#include <sys/time.h>
 
 #ifndef V4L2_CID_IRIS_ABSOLUTE
-#define V4L2_CID_IRIS_ABSOLUTE			(V4L2_CID_CAMERA_CLASS_BASE+17)
-#define V4L2_CID_IRIS_RELATIVE			(V4L2_CID_CAMERA_CLASS_BASE+18)
+#define V4L2_CID_IRIS_ABSOLUTE (V4L2_CID_CAMERA_CLASS_BASE + 17)
+#define V4L2_CID_IRIS_RELATIVE (V4L2_CID_CAMERA_CLASS_BASE + 18)
 #endif
 
-#include <QHBoxLayout>
 #include <QCheckBox>
-#include <QSlider>
 #include <QComboBox>
+#include <QHBoxLayout>
 #include <QLineEdit>
+#include <QSlider>
 
 class MainWindow;
 
-class V4L2Control : public QWidget
-{
+class V4L2Control : public QWidget {
     Q_OBJECT
-public slots:
+  public slots:
     void updateHardware();
-    virtual void updateStatus(bool hwChanged=false);
+    virtual void updateStatus(bool hwChanged = false);
     virtual void resetToDefault();
     virtual void setValue(int val) = 0;
 
-public:
+  public:
     virtual int getValue() = 0;
 
-protected:
+  protected:
     V4L2Control(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw);
     int fd;
     int cid;
@@ -54,7 +53,7 @@ protected:
     char name[32];
     QHBoxLayout layout;
 
-private:
+  private:
     MainWindow *mw;
 
     /* Not pretty we use these to keep track of the value of some special
@@ -70,23 +69,22 @@ private:
     void queryCleanup(struct v4l2_queryctrl *ctrl);
 };
 
-class V4L2IntegerControl : public V4L2Control
-{
+class V4L2IntegerControl : public V4L2Control {
     Q_OBJECT
-public:
+  public:
     V4L2IntegerControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw);
 
-public slots:
+  public slots:
     void setValue(int val);
 
-public:
+  public:
     int getValue();
 
-private slots:
+  private slots:
     void SetValueFromSlider(void);
     void SetValueFromText(void);
 
-private:
+  private:
     int minimum;
     int maximum;
     int step;
@@ -94,51 +92,48 @@ private:
     QLineEdit *le;
 };
 
-class V4L2BooleanControl : public V4L2Control
-{
+class V4L2BooleanControl : public V4L2Control {
     Q_OBJECT
-public:
+  public:
     V4L2BooleanControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw);
 
-public slots:
+  public slots:
     void setValue(int val);
 
-public:
+  public:
     int getValue();
 
-private:
+  private:
     QCheckBox *cb;
 };
 
-class V4L2MenuControl : public V4L2Control
-{
+class V4L2MenuControl : public V4L2Control {
     Q_OBJECT
-public:
+  public:
     V4L2MenuControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw);
 
-public slots:
+  public slots:
     void setValue(int val);
 
-public:
+  public:
     int getValue();
 
-private:
+  private:
     QComboBox *cb;
 
-private slots:
+  private slots:
     void menuActivated(int val);
 };
 
-class V4L2ButtonControl : public V4L2Control
-{
+class V4L2ButtonControl : public V4L2Control {
     Q_OBJECT
-public slots:
+  public slots:
     void resetToDefault();
 
-public:
+  public:
     V4L2ButtonControl(int fd, const struct v4l2_queryctrl &ctrl, QWidget *parent, MainWindow *mw);
 
-public slots:
+  public slots:
     void setValue(int) {};
     int getValue() { return 0; };
 };

--- a/src/v4l2ctrl.c
+++ b/src/v4l2ctrl.c
@@ -18,22 +18,21 @@
  */
 #include <errno.h>
 #include <fcntl.h>
+#include <libv4l2.h>
+#include <linux/types.h>
+#include <linux/videodev2.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <linux/types.h>
-#include <linux/videodev2.h>
-#include <libv4l2.h>
+#include <unistd.h>
 
 #define FORMATW "%u:%31s:%d\n"
 #define FORMATR "%u:%31c:%d\n"
 
-void usage(const char *argv0)
-{
+void usage(const char *argv0) {
     printf("Usage: %s [-d device] -s filename\n", argv0);
     printf("       %s [-d device] -l filename\n", argv0);
     printf("       %s -h\n", argv0);
@@ -43,67 +42,63 @@ void usage(const char *argv0)
     printf("-h to print this message.\n");
 }
 
-int do_save(int fd, FILE *file)
-{
+int do_save(int fd, FILE *file) {
     int i;
     struct v4l2_queryctrl ctrl;
     struct v4l2_control c;
-    
+
 #ifdef V4L2_CTRL_FLAG_NEXT_CTRL
     /* Try the extended control API first */
     ctrl.id = V4L2_CTRL_FLAG_NEXT_CTRL;
-    if(0 == v4l2_ioctl (fd, VIDIOC_QUERYCTRL, &ctrl)) {
-	do {
-	    c.id = ctrl.id;
+    if (0 == v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl)) {
+        do {
+            c.id = ctrl.id;
             ctrl.id |= V4L2_CTRL_FLAG_NEXT_CTRL;
-            if(ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
+            if (ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
                 continue;
             }
-            if(ctrl.type != V4L2_CTRL_TYPE_INTEGER &&
-               ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
-               ctrl.type != V4L2_CTRL_TYPE_MENU) {
+            if (ctrl.type != V4L2_CTRL_TYPE_INTEGER && ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
+                ctrl.type != V4L2_CTRL_TYPE_MENU) {
                 continue;
             }
-            if(v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
+            if (v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
                 fprintf(file, FORMATW, c.id, ctrl.name, c.value);
             }
-	} while(0 == v4l2_ioctl (fd, VIDIOC_QUERYCTRL, &ctrl));
+        } while (0 == v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl));
     } else
 #endif
     {
         /* Check all the standard controls */
-        for(i=V4L2_CID_BASE; i<V4L2_CID_LASTP1; i++) {
+        for (i = V4L2_CID_BASE; i < V4L2_CID_LASTP1; i++) {
             ctrl.id = i;
-            if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
-                if(ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
+            if (v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
+                if (ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
                     continue;
                 }
-                if(ctrl.type != V4L2_CTRL_TYPE_INTEGER &&
-                   ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
-                   ctrl.type != V4L2_CTRL_TYPE_MENU) {
+                if (ctrl.type != V4L2_CTRL_TYPE_INTEGER && ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
+                    ctrl.type != V4L2_CTRL_TYPE_MENU) {
                     continue;
                 }
                 c.id = i;
-                if(v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
+                if (v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
                     fprintf(file, FORMATW, i, ctrl.name, c.value);
                 }
             }
         }
 
         /* Check any custom controls */
-        for(i=V4L2_CID_PRIVATE_BASE; ; i++) {
+        for (i = V4L2_CID_PRIVATE_BASE;; i++) {
             ctrl.id = i;
-            if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
-                if(ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
+            if (v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
+                if (ctrl.flags & V4L2_CTRL_FLAG_DISABLED) {
                     continue;
                 }
-                if(ctrl.type != V4L2_CTRL_TYPE_INTEGER &&
-                   ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
-                   ctrl.type != V4L2_CTRL_TYPE_MENU) {
+                if (ctrl.type != V4L2_CTRL_TYPE_INTEGER && ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
+                    ctrl.type != V4L2_CTRL_TYPE_MENU) {
                     continue;
                 }
                 c.id = i;
-                if(v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
+                if (v4l2_ioctl(fd, VIDIOC_G_CTRL, &c) == 0) {
                     fprintf(file, FORMATW, i, ctrl.name, c.value);
                 }
             } else {
@@ -111,82 +106,75 @@ int do_save(int fd, FILE *file)
             }
         }
     }
-    
+
     return 0;
 }
 
-int do_load(int fd, FILE *file)
-{
+int do_load(int fd, FILE *file) {
     __u32 id;
     __s32 value;
     struct v4l2_queryctrl ctrl;
     struct v4l2_control c;
     char name[sizeof(ctrl.name)], *n;
-    
-    name[sizeof(ctrl.name)-1] = 0;
-    while(fscanf(file, FORMATR, &id, name, &value) == 3) {
-	n = name;
-        while(*n == ' ') {
+
+    name[sizeof(ctrl.name) - 1] = 0;
+    while (fscanf(file, FORMATR, &id, name, &value) == 3) {
+        n = name;
+        while (*n == ' ') {
             n++;
         }
         ctrl.id = id;
-        if(v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
-            if(strcmp((char *)ctrl.name, n)) {
+        if (v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &ctrl) == 0) {
+            if (strcmp((char *)ctrl.name, n)) {
                 fprintf(stderr, "Control name mismatch\n");
                 return EXIT_FAILURE;
             }
-            
-            if(ctrl.flags & (V4L2_CTRL_FLAG_READ_ONLY |
-                             V4L2_CTRL_FLAG_DISABLED |
-                             V4L2_CTRL_FLAG_GRABBED)) {
+
+            if (ctrl.flags & (V4L2_CTRL_FLAG_READ_ONLY | V4L2_CTRL_FLAG_DISABLED | V4L2_CTRL_FLAG_GRABBED)) {
                 continue;
             }
-            if(ctrl.type != V4L2_CTRL_TYPE_INTEGER &&
-               ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
-               ctrl.type != V4L2_CTRL_TYPE_MENU) {
+            if (ctrl.type != V4L2_CTRL_TYPE_INTEGER && ctrl.type != V4L2_CTRL_TYPE_BOOLEAN &&
+                ctrl.type != V4L2_CTRL_TYPE_MENU) {
                 continue;
             }
-            
+
             c.id = id;
             c.value = value;
-            if(v4l2_ioctl(fd, VIDIOC_S_CTRL, &c) != 0) {
-                fprintf(stderr, "Failed to set control \"%s\": %s\n",
-                        ctrl.name, strerror(errno));
+            if (v4l2_ioctl(fd, VIDIOC_S_CTRL, &c) != 0) {
+                fprintf(stderr, "Failed to set control \"%s\": %s\n", ctrl.name, strerror(errno));
                 continue;
             }
         } else {
-            fprintf(stderr, "Error querying control %s: %s\n",
-                    n, strerror(errno));
+            fprintf(stderr, "Error querying control %s: %s\n", n, strerror(errno));
             return EXIT_FAILURE;
         }
     }
-    
-    if(!feof(file)) {
+
+    if (!feof(file)) {
         fprintf(stderr, "Error reading from file\n");
         return EXIT_FAILURE;
     }
-    
+
     return EXIT_SUCCESS;
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     int i, fd, ret;
     int load = -1;
     const char *device = "/dev/video0";
     const char *filename, *mode;
     FILE *file;
-    
-    for(i=1; i<argc; i++) {
-        if(!strcmp(argv[i], "-d") && i<argc-1) {
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-d") && i < argc - 1) {
             device = argv[++i];
-        } else if(!strcmp(argv[i], "-s") && i<argc-1) {
+        } else if (!strcmp(argv[i], "-s") && i < argc - 1) {
             filename = argv[++i];
             load = 0;
-        } else if(!strcmp(argv[i], "-l") && i<argc-1) {
+        } else if (!strcmp(argv[i], "-l") && i < argc - 1) {
             filename = argv[++i];
             load = 1;
-        } else if(!strcmp(argv[i], "-h")) {
+        } else if (!strcmp(argv[i], "-h")) {
             usage(argv[0]);
             return EXIT_SUCCESS;
         } else {
@@ -194,39 +182,39 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
     }
-    
-    if(load < 0) {
+
+    if (load < 0) {
         usage(argv[0]);
         return EXIT_FAILURE;
     }
-    
+
     fd = v4l2_open(device, O_RDWR, 0);
-    if(fd < 0) {
+    if (fd < 0) {
         fprintf(stderr, "Unable to open %s: %s\n", device, strerror(errno));
         return EXIT_FAILURE;
     }
-    
-    if(load) {
+
+    if (load) {
         mode = "r";
     } else {
         mode = "w";
     }
-    
+
     file = fopen(filename, mode);
-    if(!file) {
+    if (!file) {
         fprintf(stderr, "Unable to open %s: %s\n", filename, strerror(errno));
         v4l2_close(fd);
         return EXIT_FAILURE;
     }
-    
-    if(load) {
+
+    if (load) {
         ret = do_load(fd, file);
     } else {
         ret = do_save(fd, file);
     }
-    
+
     fclose(file);
     v4l2_close(fd);
-    
+
     return ret;
 }

--- a/src/v4l2ucp.cpp
+++ b/src/v4l2ucp.cpp
@@ -69,6 +69,9 @@ int main(int argc, char **argv) {
             if (w) {
                 w->show();
                 windowOpened = true;
+            } else {
+                MainWindow::fileOpen();
+                windowOpened = true;
             }
         }
     }
@@ -76,6 +79,6 @@ int main(int argc, char **argv) {
     if (!windowOpened)
         exit(EXIT_FAILURE);
 
-    a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
+    a.connect(&a, &QGuiApplication::lastWindowClosed, &a, &QApplication::quit);
     return a.exec();
 }

--- a/src/v4l2ucp.cpp
+++ b/src/v4l2ucp.cpp
@@ -25,8 +25,7 @@
 
 #include "mainWindow.h"
 
-void usage(const char *argv0)
-{
+void usage(const char *argv0) {
     using std::cout;
     using std::endl;
 
@@ -40,44 +39,43 @@ void usage(const char *argv0)
     cout << "Also accepts standard Qt arguments." << endl;
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     MainWindow *w;
     QApplication a(argc, argv);
     bool windowOpened = false;
-    
-    for(int i=1; i<argc; i++) {
-        if(!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
+
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) {
             usage(argv[0]);
             exit(EXIT_SUCCESS);
         }
         w = MainWindow::openFile(argv[i]);
-        if(w) {
+        if (w) {
             w->show();
             windowOpened = true;
         }
     }
-    
-    if(argc == 1) {
+
+    if (argc == 1) {
         const char *fname = getenv("V4L2UCP_DEV");
-        if(fname) {
+        if (fname) {
             w = MainWindow::openFile(fname);
-            if(w) {
+            if (w) {
                 w->show();
                 windowOpened = true;
             }
         } else {
             w = MainWindow::openFile("/dev/video0");
-            if(w) {
+            if (w) {
                 w->show();
                 windowOpened = true;
             }
         }
     }
-    
-    if(!windowOpened)
+
+    if (!windowOpened)
         exit(EXIT_FAILURE);
-    
-    a.connect( &a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()) );
+
+    a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
     return a.exec();
 }


### PR DESCRIPTION
Hello.

I've ported v4l2ucp to Qt6 and made 3 improvements:
* Control-Class Rows are now bold
* I've added mpv and ffplay as preview-players (only really works in default settings)
* The open-Dialog now shows device-files (like video0), although this might be a Qt5/Qt6 difference.

I would like to propose two more improvements:
* starting the application without arguments tries to open /dev/video0. If that is not present I would like either to open the Open-Dialog or guess other video* files.
* ~I would remove configure preview completely. It has the potential to break previews and I can't imagine many people using it.~